### PR TITLE
Don't raise error if http code is < 400

### DIFF
--- a/nestbox_confd_client/command.py
+++ b/nestbox_confd_client/command.py
@@ -17,6 +17,9 @@ class ConfdCommand(RESTCommand):
 
     @staticmethod
     def raise_from_response(response):
+        if response.status_code < 400:
+            return
+
         if response.status_code == 503:
             raise ConfdServiceUnavailable(response)
 


### PR DESCRIPTION
If the server returns a valid json but it's not a dict, an Exception is always raised.

This fixes that.